### PR TITLE
feat(sse): Add support for hx-select attribute

### DIFF
--- a/src/sse/sse.js
+++ b/src/sse/sse.js
@@ -280,7 +280,14 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 
     var swapSpec = api.getSwapSpecification(elt)
     var target = api.getTarget(elt)
-    api.swap(target, content, swapSpec, { contextElement: elt })
+    var select = api.getClosestAttributeValue(elt, 'hx-select')
+
+    var swapOptions = {
+        select: select,
+        contextElement: elt
+    };
+
+    api.swap(target, content, swapSpec, swapOptions)
   }
 
 


### PR DESCRIPTION
The SSE extension swap function now reads the hx-select attribute from the element and passes it to `htmx.swap` in the `swapOptions`.

This allows selecting a fragment of the HTML response from an SSE event, making the extension more powerful and consistent with the rest of htmx.